### PR TITLE
fix(node-federation): fallback to node-fetch automatically

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Module Federation for Node.js",
   "main": "index.js",
   "peerDependencies": {
-    "webpack": "5.40.0"
+    "webpack": "5.40.0",
+    "node-fetch": "^3.2.10"
   }
 }

--- a/src/NodeFederationPlugin.js
+++ b/src/NodeFederationPlugin.js
@@ -32,7 +32,7 @@ const executeLoadTemplate = `
         console.log("executing remote load", scriptUrl);
         return new Promise(function (resolve, reject) {
    
-         (global.webpackChunkLoad || fetch)(scriptUrl).then(function(res){
+         (global.webpackChunkLoad || global.fetch || require("node-fetch"))(scriptUrl).then(function(res){
             return res.text();
           }).then(function(scriptContent){
             try {


### PR DESCRIPTION
It should fall back to node-fetch when a custom chunkLoad mechanism or fetch does not exist