### PR TITLE
Fix path to Webpack HMR runtime

### DIFF
--- a/src/LoadFileChunkLoadingRuntimeModule.js
+++ b/src/LoadFileChunkLoadingRuntimeModule.js
@@ -352,7 +352,7 @@ class ReadFileChunkLoadingRuntimeModule extends RuntimeModule {
             '}',
             '',
             Template.getFunctionContent(
-              require('../hmr/JavascriptHotModuleReplacement.runtime.js')
+              require('webpack/lib/hmr/JavascriptHotModuleReplacement.runtime.js')
             )
               .replace(/\$key\$/g, 'readFileVm')
               .replace(/\$installedChunks\$/g, 'installedChunks')


### PR DESCRIPTION
resolves: https://github.com/module-federation/node/issues/7

Update path to Webpack's HMR runtime to not depend on relative paths.