### PR TITLE
feat: use node vm context to execute remote

### DIFF
--- a/src/NodeFederationPlugin.js
+++ b/src/NodeFederationPlugin.js
@@ -36,13 +36,8 @@ const executeLoadTemplate = `
             return res.text();
           }).then(function(scriptContent){
             try {
-              const vmContext = {
-                module,
-                require,
-                __dirname,
-                global,
-                URL
-              };
+              const vmContext = { exports, require, module, global, __filename, __dirname, URL };
+
               const remote = vm.runInNewContext(scriptContent + '\\nmodule.exports', vmContext, { filename: 'node-federation-loader-' + moduleName + '.vm' });
               
               /* TODO: need something like a chunk loading queue, this can lead to async issues

--- a/src/NodeFederationPlugin.js
+++ b/src/NodeFederationPlugin.js
@@ -29,7 +29,7 @@ const executeLoadTemplate = `
         const scriptUrl = remoteUrl.split("@")[1];
         const moduleName = remoteUrl.split("@")[0];
         console.log("executing remote load", scriptUrl);
-        const vm = require('node:vm');
+        const vm = require('vm');
         return new Promise(function (resolve, reject) {
    
          (global.webpackChunkLoad || global.fetch || require("node-fetch"))(scriptUrl).then(function(res){

--- a/src/NodeFederationPlugin.js
+++ b/src/NodeFederationPlugin.js
@@ -22,7 +22,6 @@
 
 //TODO: should use extractUrlAndGlobal from internal.js
 //TODO: should use Template system like LoadFileChunk runtime does.
-//TODO: should use vm.runInThisContext instead of eval
 //TODO: global.webpackChunkLoad could use a better convention? I have to use a special http client to get out of my infra firewall
 const executeLoadTemplate = `
     function executeLoad(remoteUrl) {


### PR DESCRIPTION
Uses a node VM to execute the remote code in a new context.

I have had to pass certain parameters for the context as they don't exist by default in a VM see Lines 40 to 46.

Not sure if you had any other ideas for implementation here.

Note: This seems to be a breaking change as remotes built with the previous method fail when being executed.

Also includes @apehead 's changes in https://github.com/module-federation/node/pull/9