### PR TITLE
Fix validation error with UniversalFederationPlugin

### DIFF
--- a/src/UniversalFederationPlugin.js
+++ b/src/UniversalFederationPlugin.js
@@ -10,16 +10,16 @@ class UniversalFederationPlugin {
   }
 
   apply(compiler) {
-    const isServer = this.options.isServer || compiler.options.name === 'server';
+    const {isServer, ...options} = this.options;
     const {webpack} = compiler;
 
-    if(isServer) {
-      new NodeFederationPlugin({experiments: this.experiments, ...this.options}).apply(compiler);
-      new StreamingTargetPlugin(this.options).apply(compiler);
+    if(isServer || compiler.options.name === 'server') {
+      new NodeFederationPlugin({experiments: this.experiments, ...options}).apply(compiler);
+      new StreamingTargetPlugin(options).apply(compiler);
     } else {
       new (this.context.ModuleFederationPlugin || (webpack && webpack.container.ModuleFederationPlugin) ||
         require('webpack/lib/container/ModuleFederationPlugin'))(
-        this.options
+        options
       ).apply(compiler);
     }
   }


### PR DESCRIPTION
```
ValidationError: Invalid options object. Module Federation Plugin has been initialized using an options object that does not match the API schema.
 - options has an unknown property 'isServer'.
```
Above error was thrown when passing `isServer` to the plugin due to the whole options object got passed further to ModuleFederationPlugin & `isServer` was not a valid option. Just need to extract it out & pass through the rest.